### PR TITLE
strip whitespace of stash count

### DIFF
--- a/shell/gitstatus.sh
+++ b/shell/gitstatus.sh
@@ -87,7 +87,7 @@ EOF
         branch=":${hashid:0:7}"
     fi
 
-    local stashed=$(git stash list | wc -l)
+    local stashed=$(git stash list | wc -l | sed 's/^ *//')
 
     echo "${PREFIX}IS_REPOSITORY 1"
     echo "${PREFIX}BRANCH $branch"


### PR DESCRIPTION
On my machine (macOS Catalina) the formatting of the shell only git_super_status has some superfluous spaces (see first screenshot). 

<img width="380" alt="Screenshot 2020-02-23 at 2 21 39 AM" src="https://user-images.githubusercontent.com/29301569/75101886-c9cbd900-55db-11ea-886e-a3619246920e.png">

The reason for that is that `wc -l` formats the output. Using `sed` I can strip the whitespace and the formatting of the prompt looks good again (see second screenshot).
<img width="375" alt="Screenshot 2020-02-23 at 2 22 11 AM" src="https://user-images.githubusercontent.com/29301569/75101914-0697d000-55dc-11ea-8ef3-c7f1fbf43aa2.png">
