### PR TITLE
Handle slashes in the branch name for upstream branch folding

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -147,7 +147,7 @@ git_build_status() {
             add_color_reset
         elif [[ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -gt "0" ]] && [ -n "$REPO_UPSTREAM" ] && [ "$REPO_UPSTREAM" != ".." ]; then
             local parts=( "${(s:/:)REPO_UPSTREAM}" )
-            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ "$parts[2]" = "$REPO_BRANCH" ]; then
+            if [ "$ZSH_GIT_PROMPT_SHOW_UPSTREAM" -eq "2" ] && [ "${(j:/:)parts[@]:1}" = "$REPO_BRANCH" ]; then
                 REPO_UPSTREAM="$parts[1]"
             fi
             add_theme_var UPSTREAM_FRONT


### PR DESCRIPTION
If the branch name includes `/` character(s) the upstream folding fails
as we only compare a sub-part of the branch with the upstream branch
which still has the `/` character(s) in it.

Here we manipulate the `parts` array prior to the compare so that we can
include `/`'s when they did exist in the remote branch name.

`${x[@]:1}` gets all but the first element of the `$x` array
`${(j:/:)x}` joins all elements of `$x` with `/`