### PR TITLE
Remove what looks like debugging code

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -96,10 +96,7 @@ repo_check() {
 repo_check_not() {
     local content=""
     local cmd="content=\"\$REPO_$1\""
-    echo "$cmd" >> /tmp/zp.log
     eval $cmd
-    echo "$cmd" >> /tmp/zp.log
-    echo "HERE: $content" >> /tmp/zp.log
     [ -n "$content" ] && [ "$content" = "0" ]
 }
 


### PR DESCRIPTION
I was running into a repeated error on a machine where there was no `/tmp` directory.

If we need to keep the logging around, we should be respecting `$TMPDIR` and I can make a separate patch for that