### PR TITLE
Add behind ahead separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ These are the defaults:
     ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
     ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
     ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%2G%}"
+    ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SEPARATOR=""
     ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%2G%}"
     ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}%{⚑%G%}"
     ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}%{…%G%}"

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -156,10 +156,14 @@ git_build_status() {
         if repo_check BEHIND || repo_check AHEAD; then
             add_str " "
         fi
+
         repo_info_with_check BEHIND
+        if repo_check BEHIND && repo_check AHEAD; then
+            add_str "$ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SEPARATOR"
+        fi
         repo_info_with_check AHEAD
 
-        STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_SEPARATOR"
+        add_str "$ZSH_THEME_GIT_PROMPT_SEPARATOR"
 
         repo_info_with_check STAGED
         repo_info_with_check CONFLICTS
@@ -233,6 +237,7 @@ ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[red]%}%{●%G%}"
 ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
 ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%1G%}"
+ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SEPARATOR=""
 ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%1G%}"
 ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}%{⚑%G%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}%{…%G%}"


### PR DESCRIPTION
I like my prompt like this: `(master -2/+1 ✔)`. When still using olivierverdier/zsh-git-prompt I overwrote the git_super_status function to achieve that. Now I made the switch to zsh-git-prompt/zsh-git-prompt and as the code changed a lot it made more sense to me to extend the plugin's functionality. Maybe others have some use for the new separator as well?