### PR TITLE
Add flags to show/hide component

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ There is now a Haskell implementation as well, which can be four to six times fa
 
 - Define the variable `ZSH_GIT_PROMPT_SHOW_UPSTREAM=2` to show the remote as above but omit the remote branch when its name is equal to the local branch.
 
+- To disable any status component(s), set the following control variables to `0`. All default to `1` (enabled) unless otherwise noted.
+  - `ZSH_GIT_PROMPT_SHOW_UPSTREAM`
+    - Defaults to `0` (off)
+  - `ZSH_GIT_PROMPT_SHOW_BEHIND`
+  - `ZSH_GIT_PROMPT_SHOW_AHEAD`
+  - `ZSH_GIT_PROMPT_SHOW_REBASE`
+  - `ZSH_GIT_PROMPT_SHOW_MERGING`
+  - `ZSH_GIT_PROMPT_SHOW_BISECT`
+  - `ZSH_GIT_PROMPT_SHOW_STAGED`
+  - `ZSH_GIT_PROMPT_SHOW_CONFLICTS`
+  - `ZSH_GIT_PROMPT_SHOW_CHANGED`
+  - `ZSH_GIT_PROMPT_SHOW_UNTRACKED`
+  - `ZSH_GIT_PROMPT_SHOW_STASHED`
+
 Demo:
 
 ![upstream example](https://user-images.githubusercontent.com/470400/40869339-52ae782c-65e7-11e8-89a9-2e053b3f8198.png)

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -119,7 +119,8 @@ add_theme_var() {
 }
 
 repo_info_with_check() {
-    if repo_check $1; then
+    local show_var="ZSH_GIT_PROMPT_SHOW_$1"
+    if [ "${(P)show_var}" -ne "0" ] && repo_check $1; then
         add_theme_var $1
         add_repo_var $1
         add_color_reset
@@ -154,7 +155,7 @@ git_build_status() {
             add_color_reset
         fi
 
-        if repo_check BEHIND || repo_check AHEAD; then
+        if (repo_check BEHIND && [ "$ZSH_GIT_PROMPT_SHOW_BEHIND" -ne "0" ]) || (repo_check AHEAD && [ "$ZSH_GIT_PROMPT_SHOW_AHEAD" -ne "0" ]); then
             add_str " "
         fi
 
@@ -173,11 +174,11 @@ git_build_status() {
         repo_info_with_check STASHED
 
         local clean=0
-        if repo_check_not STAGED &&
-                repo_check_not CONFLICTS &&
-                repo_check_not CHANGED &&
-                repo_check_not UNTRACKED &&
-                repo_check_not STASHED; then
+        if ([ "$ZSH_GIT_PROMPT_SHOW_STAGED" -eq "0" ] || repo_check_not STAGED) &&
+               ([ "$ZSH_GIT_PROMPT_SHOW_CONFLICTS" -eq "0" ] || repo_check_not CONFLICTS) &&
+               ([ "$ZSH_GIT_PROMPT_SHOW_CHANGED" -eq "0" ] || repo_check_not CHANGED) &&
+               ([ "$ZSH_GIT_PROMPT_SHOW_UNTRACKED" -eq "0" ] || repo_check_not UNTRACKED) &&
+               ([ "$ZSH_GIT_PROMPT_SHOW_STASHED" -eq "0" ] || repo_check_not STASHED); then
             add_theme_var CLEAN
             add_color_reset
             clean=1
@@ -251,5 +252,18 @@ ZSH_THEME_GIT_PROMPT_UPSTREAM_END="%{${reset_color}%}}"
 ZSH_THEME_GIT_PROMPT_MERGING="%{$fg_bold[magenta]%}|MERGING%{${reset_color}%}"
 ZSH_THEME_GIT_PROMPT_REBASE="%{$fg_bold[magenta]%}|REBASE%{${reset_color}%} "
 ZSH_THEME_GIT_PROMPT_BISECT="%{$fg_bold[magenta]%}|BISECT%{${reset_color}%} "
+
+# Settings defaults
+ZSH_GIT_PROMPT_SHOW_UPSTREAM=0
+ZSH_GIT_PROMPT_SHOW_BEHIND=1
+ZSH_GIT_PROMPT_SHOW_AHEAD=1
+ZSH_GIT_PROMPT_SHOW_REBASE=1
+ZSH_GIT_PROMPT_SHOW_MERGING=1
+ZSH_GIT_PROMPT_SHOW_BISECT=1
+ZSH_GIT_PROMPT_SHOW_STAGED=1
+ZSH_GIT_PROMPT_SHOW_CONFLICTS=1
+ZSH_GIT_PROMPT_SHOW_CHANGED=1
+ZSH_GIT_PROMPT_SHOW_UNTRACKED=1
+ZSH_GIT_PROMPT_SHOW_STASHED=1
 
 # vim: filetype=zsh: tabstop=4 shiftwidth=4 expandtab

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -88,16 +88,14 @@ update_current_git_vars() {
 }
 
 repo_check() {
-    local content=""
-    local cmd="content=\"\$REPO_$1\""
-    eval $cmd
+    local repo_var="REPO_$1"
+    local content="${(P)repo_var}"
     [ -n "$content" ] && [ "$content" != "0" ]
 }
 
 repo_check_not() {
-    local content=""
-    local cmd="content=\"\$REPO_$1\""
-    eval $cmd
+    local repo_var="REPO_$1"
+    local content="${(P)repo_var}"
     [ -n "$content" ] && [ "$content" = "0" ]
 }
 
@@ -111,11 +109,13 @@ add_color_reset() {
 }
 
 add_repo_var() {
-    eval STATUS="\$STATUS\$REPO_$1"
+    local repo_var="REPO_$1"
+    STATUS="${STATUS}${(P)repo_var}"
 }
 
 add_theme_var() {
-    eval STATUS="\$STATUS\$ZSH_THEME_GIT_PROMPT_$1"
+    local theme_var="ZSH_THEME_GIT_PROMPT_$1"
+    STATUS="${STATUS}${(P)theme_var}"
 }
 
 repo_info_with_check() {


### PR DESCRIPTION
Adds flags to enable/disable every (I think) component of the status display. Should fix https://github.com/zsh-git-prompt/zsh-git-prompt/issues/14 at least.

I personally use this now to also disable the stash display as well.

This also refactors some of the functions that were using `eval` to have dynamic variable names with zsh's parameter expansion instead. See https://zsh.sourceforge.io/Doc/Release/Expansion.html for details. I couldn't find a reason to _not_ do this - but I could conceive of a world where I missed one, so please let me know.