### PR TITLE
Proposal to add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ haskell/.bin
 python/.tox
 **/__pycache__
 .pytest_cache
+
+
+# Test repo
+tests/test_repo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+ZSH="zsh"
+
+all: test
+
+test:
+	@$(ZSH) -n zshrc.sh shell/gitstatus.sh
+	@$(ZSH) tests/run_tests.sh
+
+.PHONY: all test

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ REPO_MERGING                | Whether we are merging.
 REPO_REBASE                 | Information about rebasing. 
 
 
+## Tests
+See [`tests/README.md`](./tests/README.md)
+
 
 ## Related projects
 

--- a/tests/.gitconfig
+++ b/tests/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = ZSH Git Prompt
+	email = zsh@/dev/null

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,15 @@
 Testing is done by creating a local test git repository, modifying the state of it, and testing the raw output of the status line against the themed expectations.
 
 
+# Running tests
+
+`make test`
+
+OR
+
+`./tests/run_tests.sh`
+
+
 # Adding a new test case
 Create a new file in [`tests/test_cases/`](./test_cases) with your script. The repository is recreated between test cases so feel free to modify it's state. Do not alter files outside of the repository if at all possible however!
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,20 @@
+# Testing
+
+Testing is done by creating a local test git repository, modifying the state of it, and testing the raw output of the status line against the themed expectations.
+
+
+# Adding a new test case
+Create a new file in [`tests/test_cases/`](./test_cases) with your script. The repository is recreated between test cases so feel free to modify it's state. Do not alter files outside of the repository if at all possible however!
+
+
+## Available functions
+- `assert_equal` - sets an error code if expected input does not match actual input
+- `run_super_status` - runs the `zsh-git-prompt` script and captures the output
+
+
+## Notes
+
+### Themes
+As this tests the default configuration, with colored themes, it can be a bit difficult to debug new test cases sometimes due to the printed output's color codes being parse by your local terminal. If you see output that looks identical, colors and all, a `reset_color` was probably missed - look for "empty" sets of braces that might need to look like `%{${reset_color}%}`
+
+See `run_tests.sh` for implementation details

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,50 @@
+#!/bin/zsh
+
+if [ -n "$ZSH_VERSION" ]; then
+    # Always has path to this directory
+    # A: finds the absolute path, even if this is symlinked
+    # h: equivalent to dirname
+    export __RUN_TEST_DIR=${0:A:h}
+else
+    echo "Must use ZSH to run tests!"
+    exit 1
+fi
+
+source "${__RUN_TEST_DIR}/setup_tests.sh"
+
+ZSHRCSH_PATH="${__RUN_TEST_DIR}/../zshrc.sh"
+
+run_super_status() {
+    (cd "${TEST_REPO_DIR}" && zsh -f "$ZSHRCSH_PATH" --debug)
+}
+
+# https://stackoverflow.com/a/15612499
+function assertEquals()
+{
+    msg=$1; shift
+    expected=$1; shift
+    actual=$1; shift
+    if [ "$expected" != "$actual" ]; then
+        echo "$msg EXPECTED=$expected ACTUAL=$actual"
+        exit 1
+    fi
+}
+
+FAILURES=0
+
+prepare_test_env && (
+    assertEquals "Clean" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg_bold[green]%}%{✔%G%}%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"
+); ((FAILURES+=$?)); cleanup_test_env
+
+prepare_test_env && (
+    touch "${TEST_REPO_DIR}/untracked_file_1"
+    touch "${TEST_REPO_DIR}/untracked_file_2"
+
+    assertEquals "Two untracked files" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg[cyan]%}%{…%G%}2%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"
+); ((FAILURES+=$?)); cleanup_test_env
+
+if [[ "$FAILURES" -eq "0" ]]; then
+    echo "PASS"
+fi
+
+exit $FAILURES

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -50,11 +50,18 @@ function run_all_tests()
 
     for test_full_path in ${TEST_CASE_DIR}/*; do
         test_case="$(basename "$test_full_path")"
-        echo "Testing: $test_case"
         ((TOTAL+=1))
         run_test $test_case
-        ((FAILURES+=$?))
+
+        if [[ "$?" -ne "0" ]]; then
+            echo -n "x"
+            ((FAILURES+=1))
+        else
+            echo -n "."
+        fi
     done
+
+    echo
 
     PASSED=$((TOTAL-FAILURES))
     echo "$PASSED/$TOTAL PASSED"

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -14,7 +14,7 @@ TEST_REPO_DIR="${__RUN_TEST_DIR}/test_repo"
 MARKER_FILE_NAME="zsh-git-prompt-marker"
 
 git_commit() {
-    GIT_CONFIG_GLOBAL="/dev/null" git commit --no-gpg-sign -q $@
+    GIT_CONFIG_GLOBAL="${__RUN_TEST_DIR}/.gitconfig" git commit --no-gpg-sign -q $@
 }
 
 prepare_test_env() {

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -1,0 +1,39 @@
+#!/bin/zsh
+
+if [ -n "$ZSH_VERSION" ]; then
+    # Always has path to this directory
+    # A: finds the absolute path, even if this is symlinked
+    # h: equivalent to dirname
+    export __RUN_TEST_DIR=${0:A:h}
+else
+    echo "Must use ZSH to run tests!"
+    exit 1
+fi
+
+TEST_REPO_DIR="${__RUN_TEST_DIR}/test_repo"
+MARKER_FILE_NAME="zsh-git-prompt-marker"
+
+git_commit() {
+    GIT_CONFIG_GLOBAL="/dev/null" git commit --no-gpg-sign -q $@
+}
+
+prepare_test_env() {
+    autoload -U colors
+    colors
+
+    unset PS1
+    unset GIT_PROMPT_EXECUTABLE
+
+    mkdir "${TEST_REPO_DIR}" && (cd "${TEST_REPO_DIR}" && git init -q && git symbolic-ref HEAD refs/heads/main && touch "$MARKER_FILE_NAME" && git add "$MARKER_FILE_NAME" && git_commit -m "Initial Commit")
+}
+
+cleanup_test_env() {
+    if [[ "$(id -u)" -eq "0" ]]; then
+        echo "Refusing to cleanup as root; risk of damage is unacceptable. Remove '${TEST_REPO_DIR}' manually if safe."
+        return 1
+    elif [[ ! -f "${TEST_REPO_DIR}/${MARKER_FILE_NAME}" ]]; then
+        echo "Cannot find marker file in '${TEST_REPO_DIR}', refusing to delete; risk of wrong folder is unacceptable. Remove '${TEST_REPO_DIR}' manually if safe."
+        return 2
+    fi
+    rm -rf "${TEST_REPO_DIR}"
+}

--- a/tests/test_cases/3_added_files
+++ b/tests/test_cases/3_added_files
@@ -1,0 +1,5 @@
+touch "added_file_1" && git add "added_file_1"
+touch "added_file_2" && git add "added_file_2"
+touch "added_file_3" && git add "added_file_3"
+
+assert_equals "Three added files" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg[red]%}%{●%G%}3%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"

--- a/tests/test_cases/added_changed_untracked
+++ b/tests/test_cases/added_changed_untracked
@@ -1,0 +1,9 @@
+touch "untracked_file_1"
+touch "untracked_file_2"
+touch "added_file_1" && git add "added_file_1"
+touch "added_file_2" && git add "added_file_2"
+touch "added_file_3" && git add "added_file_3"
+rm "added_file_3"
+
+assert_equals "Added Changed Untracked" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg[red]%}%{●%G%}3%{${reset_color}%}%{$fg[blue]%}%{✚%G%}1%{${reset_color}%}%{$fg[cyan]%}%{…%G%}2%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"
+

--- a/tests/test_cases/clean
+++ b/tests/test_cases/clean
@@ -1,0 +1,1 @@
+assert_equals "Clean" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg_bold[green]%}%{✔%G%}%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"

--- a/tests/test_cases/python_clean
+++ b/tests/test_cases/python_clean
@@ -1,0 +1,1 @@
+assert_equals "Clean" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg_bold[green]%}%{✔%G%}%{${reset_color}%}]%{${reset_color}%}" "$(GIT_PROMPT_EXECUTABLE="python" run_super_status)"

--- a/tests/test_cases/two_untracked_files
+++ b/tests/test_cases/two_untracked_files
@@ -1,0 +1,4 @@
+touch "untracked_file_1"
+touch "untracked_file_2"
+
+assert_equals "Two untracked files" "%{${reset_color}%}[%{$fg_bold[magenta]%}main%{${reset_color}%} L%{${reset_color}%}|%{$fg[cyan]%}%{…%G%}2%{${reset_color}%}]%{${reset_color}%}" "$(run_super_status)"

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -206,16 +206,6 @@ git_super_status() {
     git_build_status
 }
 
-
-
-if [ "$1" = "--debug" ]; then
-    __GIT_PROMPT_DEBUG="yes"
-    update_current_git_vars
-    git_super_status
-    echo
-    exit
-fi
-
 # Load required modules
 autoload -U add-zsh-hook
 autoload -U colors
@@ -265,5 +255,17 @@ ZSH_GIT_PROMPT_SHOW_CONFLICTS=1
 ZSH_GIT_PROMPT_SHOW_CHANGED=1
 ZSH_GIT_PROMPT_SHOW_UNTRACKED=1
 ZSH_GIT_PROMPT_SHOW_STASHED=1
+
+if [ "$1" = "--debug" ]; then
+    __GIT_PROMPT_DEBUG="yes"
+    update_current_git_vars
+    git_super_status
+    echo
+    exit
+elif [ "$1" = "--test" ]; then
+    update_current_git_vars
+    repo_status
+    exit
+fi
 
 # vim: filetype=zsh: tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
# Overview

IMHO, one of the trickier things about working on shell projects like this is ensuring one doesn't make an accidental edge case break. To that end, I've started some integration tests. The test cases aren't nearly complete and the commits could probably do with a good squash at the end, but I wanted to start a discussion as to whether this was wanted by anyone aside from me and if this was a valid starting point.

# Goal
My eventual goal with this would be to achieve near full coverage of `zshrc.sh` as well as the ability to automate these tests somewhat with github actions etc. This would also serve the conversation in #21 about finding a minimum zsh version as it would be possible to bisect zsh versions with these tests.

# Strategy
These tests are intended to each create a git repo in a certain precise state, run the `git_super_status` command and validate the produced output, theme colors and all.

## Advantages
- Complete output validation in a textual form allows for precise diffs and avoids user-specific configuration interference
- Test environments are easy to understand
- A large measure of change-security is introduced

## Disadvantages/risks
- Tests can be tedious to initially write, as color codes often need to be manually re-inserted
- Test lines are themselves not easy to read
- It's possible these tests are more bound by zsh version than anticipated.
- Outside environment impacts must be manually avoided - this means that they might slip in anyways by accident.


Any & all thoughts on this approach are appreciated, thank you!





