### PR TITLE
Update Stack resolver to lts-20.6

### DIFF
--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.0
+resolver: lts-20.6
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
The current resolver of lts-5.0 does not have a toolchain from aarch64, so is not able to work on M1 macOS.