### PR TITLE
Theme support for behind/ahead section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,16 +147,20 @@ These are the defaults:
     ZSH_THEME_GIT_PROMPT_STAGED="%{$fg[red]%}%{●%G%}"
     ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
     ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
-    ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%2G%}"
+    ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%1G%}"
     ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SEPARATOR=""
-    ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%2G%}"
+    ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SECTION_SEPARATOR=" "
+    ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%1G%}"
     ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}%{⚑%G%}"
     ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}%{…%G%}"
     ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}%{✔%G%}"
     ZSH_THEME_GIT_PROMPT_LOCAL=" L"
     # The remote branch will be shown between these two
-    ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT=" {%{$fg_bold[blue]%}"
+    ZSH_THEME_GIT_PROMPT_UPSTREAM_FRONT=" {%{$fg[blue]%}"
     ZSH_THEME_GIT_PROMPT_UPSTREAM_END="%{${reset_color}%}}"
+    ZSH_THEME_GIT_PROMPT_MERGING="%{$fg_bold[magenta]%}|MERGING%{${reset_color}%}"
+    ZSH_THEME_GIT_PROMPT_REBASE="%{$fg_bold[magenta]%}|REBASE%{${reset_color}%} "
+    ZSH_THEME_GIT_PROMPT_BISECT="%{$fg_bold[magenta]%}|BISECT%{${reset_color}%} "
 ```
 
 **Enjoy!**

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -156,7 +156,7 @@ git_build_status() {
         fi
 
         if (repo_check BEHIND && [ "$ZSH_GIT_PROMPT_SHOW_BEHIND" -ne "0" ]) || (repo_check AHEAD && [ "$ZSH_GIT_PROMPT_SHOW_AHEAD" -ne "0" ]); then
-            add_str " "
+            add_str $ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SECTION_SEPARATOR
         fi
 
         repo_info_with_check BEHIND
@@ -241,6 +241,7 @@ ZSH_THEME_GIT_PROMPT_CONFLICTS="%{$fg[red]%}%{✖%G%}"
 ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%1G%}"
 ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SEPARATOR=""
+ZSH_THEME_GIT_PROMPT_BEHIND_AHEAD_SECTION_SEPARATOR=" "
 ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%1G%}"
 ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}%{⚑%G%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}%{…%G%}"


### PR DESCRIPTION
Adding customization for this section separator, rather than hardcoding it to a space.

I also pulled the current defaults into the README - many were out of date.